### PR TITLE
fix(#16): logout() ne réinitialise pas les tâches

### DIFF
--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -101,7 +101,12 @@ export function useTasks() {
 
   const logout = useCallback(() => {
     setUser(null)
+    setTasks({})
+    setUserNameState('')
+    setSelDate(toKey(new Date()))
+    setSelTaskId(null)
     saveAuth(null)
+    saveTasks({})
   }, [])
 
   // ── Navigation ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #16 — [BUG] logout() ne réinitialise pas les tâches — fuite de données entre utilisateurs

### What changed

- `src/hooks/useTasks.js`: `logout()` réinitialise maintenant l'intégralité de l'état (`tasks`, `userName`, `selDate`, `selTaskId`) et purge AsyncStorage (`saveTasks({})`)

### Why

`logout()` n'effaçait que `user`. Si un second utilisateur se connectait sur le même appareil, il voyait toutes les données du premier.

### Test plan

- [x] Se connecter, créer des tâches, se déconnecter → vérifier que `tasks` est vide dans l'état
- [x] Se reconnecter avec un autre profil → aucune tâche du premier utilisateur visible
- [x] `npx expo export --platform ios --no-minify` → 0 erreurs

Closes #16