### PR TITLE
fix(dark-mode): correct theme tokens across TaskCard, Timeline, Stats and Profile

### DIFF
--- a/src/components/TaskCard.js
+++ b/src/components/TaskCard.js
@@ -36,6 +36,7 @@ const TaskCard = memo(function TaskCard({ darkMode,
     onUpdateSession?.(group.sessionIds[0], newStart, newEnd)
     setEditingId(null)
   }
+  const C      = darkMode ? COLORS.dark : COLORS.light
   const status  = getTaskStatus(task)
   const totalMs = getTotalMs(task, now)
   const palette = getTaskPalette(task)
@@ -65,6 +66,7 @@ const TaskCard = memo(function TaskCard({ darkMode,
     >
       <View style={[
         styles.card,
+        { backgroundColor: C.bgCard, borderColor: C.border },
         isDone && { opacity: 0.75 },
       ]}>
         {/* Top row: status pill + time + heart */}
@@ -103,7 +105,7 @@ const TaskCard = memo(function TaskCard({ darkMode,
             {status === 'idle' && (
               <View style={{ flexDirection: 'row', gap: 6 }}>
                 <TouchableOpacity
-                  style={[styles.miniBtn, { backgroundColor: isToday ? palette.dot : ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).border }]}
+                  style={[styles.miniBtn, { backgroundColor: isToday ? palette.dot : ( C).border }]}
                   onPress={onStart}
                   activeOpacity={0.8}
                   disabled={!isToday}
@@ -114,7 +116,7 @@ const TaskCard = memo(function TaskCard({ darkMode,
                 </TouchableOpacity>
                 {(task.sessions?.length ?? 0) > 0 && isToday && (
                   <TouchableOpacity
-                    style={[styles.miniBtn, { backgroundColor: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).emerald }]}
+                    style={[styles.miniBtn, { backgroundColor: ( C).emerald }]}
                     onPress={onDone}
                     activeOpacity={0.8}
                   >
@@ -140,7 +142,7 @@ const TaskCard = memo(function TaskCard({ darkMode,
                   <Text style={[styles.miniBtnOutlineText, { color: palette.dot }]}>|| Pause</Text>
                 </TouchableOpacity>
                 <TouchableOpacity
-                  style={[styles.miniBtn, { backgroundColor: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).emerald }]}
+                  style={[styles.miniBtn, { backgroundColor: ( C).emerald }]}
                   onPress={onDone}
                   activeOpacity={0.8}
                 >
@@ -193,7 +195,7 @@ const TaskCard = memo(function TaskCard({ darkMode,
             {/* Tags (if expanded) */}
             {taskTag && (
               <View style={{ marginBottom: 16 }}>
-                <Text style={{ fontSize: 11, fontWeight: '600', color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkMuted, marginBottom: 8, letterSpacing: 0.5 }}>CURRENT TAG</Text>
+                <Text style={{ fontSize: 11, fontWeight: '600', color: ( C).inkMuted, marginBottom: 8, letterSpacing: 0.5 }}>CURRENT TAG</Text>
                 <View style={styles.tagsRow}>
                   <View style={[styles.tagChip, { backgroundColor: taskTag.bg, borderColor: taskTag.dot + '40' }]}>
                     <Text style={[styles.tagText, { color: taskTag.dot }]}>{taskTag.label}</Text>
@@ -206,7 +208,7 @@ const TaskCard = memo(function TaskCard({ darkMode,
             {task.sessions && task.sessions.length > 0 && (
               <View style={{ marginBottom: 16 }}>
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
-                  <Text style={{ fontSize: 11, fontWeight: '600', color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkMuted, letterSpacing: 0.5 }}>
+                  <Text style={{ fontSize: 11, fontWeight: '600', color: ( C).inkMuted, letterSpacing: 0.5 }}>
                     SESSIONS (LAST 5 OF {task.sessions.length})
                   </Text>
                 </View>
@@ -233,19 +235,19 @@ const TaskCard = memo(function TaskCard({ darkMode,
                     const isEditing = editingId === group.groupKey
 
                     return (
-                      <View key={sId} style={{ marginBottom: 8, backgroundColor: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).bgInput, padding: 8, borderRadius: 10 }}>
+                      <View key={sId} style={{ marginBottom: 8, backgroundColor: ( C).bgInput, padding: 8, borderRadius: 10 }}>
                         {isEditing ? (
                           <View style={{ gap: 8 }}>
                             <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
                               <TextInput
-                                style={{ flex: 1, height: 36, backgroundColor: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).bgApp, borderRadius: 6, paddingHorizontal: 8, fontSize: 14, color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkPrimary, fontWeight: '700' }}
+                                style={{ flex: 1, height: 36, backgroundColor: ( C).bgApp, borderRadius: 6, paddingHorizontal: 8, fontSize: 14, color: ( C).inkPrimary, fontWeight: '700' }}
                                 value={editStart}
                                 onChangeText={setEditStart}
                                 placeholder="Start"
                               />
-                              <Text style={{ color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkMuted }}>to</Text>
+                              <Text style={{ color: ( C).inkMuted }}>to</Text>
                               <TextInput
-                                style={{ flex: 1, height: 36, backgroundColor: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).bgApp, borderRadius: 6, paddingHorizontal: 8, fontSize: 14, color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkPrimary, fontWeight: '700' }}
+                                style={{ flex: 1, height: 36, backgroundColor: ( C).bgApp, borderRadius: 6, paddingHorizontal: 8, fontSize: 14, color: ( C).inkPrimary, fontWeight: '700' }}
                                 value={editEnd}
                                 onChangeText={setEditEnd}
                                 placeholder="End"
@@ -253,7 +255,7 @@ const TaskCard = memo(function TaskCard({ darkMode,
                             </View>
                             <View style={{ flexDirection: 'row', justifyContent: 'flex-end', gap: 8 }}>
                               <TouchableOpacity onPress={() => setEditingId(null)} style={{ padding: 6 }}>
-                                <Text style={{ color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkMuted, fontSize: 12, fontWeight: '700' }}>Cancel</Text>
+                                <Text style={{ color: ( C).inkMuted, fontSize: 12, fontWeight: '700' }}>Cancel</Text>
                               </TouchableOpacity>
                               <TouchableOpacity onPress={() => saveEdit(group)} style={{ backgroundColor: palette.dot, paddingHorizontal: 12, paddingVertical: 6, borderRadius: 6 }}>
                                 <Text style={{ color: '#FFF', fontSize: 12, fontWeight: '700' }}>Save</Text>
@@ -270,15 +272,15 @@ const TaskCard = memo(function TaskCard({ darkMode,
                               {formatTime(group.startTime)}  <Text style={{ color: palette.dot, opacity: 0.6 }}>to</Text>  {group.endTime ? formatTime(group.endTime) : <Text style={{ color: palette.dot, fontStyle: 'italic' }}>Active now</Text>}
                             </Text>
                             <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-                              <Text style={{ fontSize: 12, color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkMuted }}>{formatShort(group.totalDuration)}</Text>
+                              <Text style={{ fontSize: 12, color: ( C).inkMuted }}>{formatShort(group.totalDuration)}</Text>
                               <TouchableOpacity 
                                 onPress={() => {
                                   group.sessionIds.forEach(id => onDeleteSession && onDeleteSession(id))
                                 }} 
                                 hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
                               >
-                                <View style={{ backgroundColor: `${( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).red}15`, width: 24, height: 24, borderRadius: 12, alignItems: 'center', justifyContent: 'center' }}>
-                                  <Text style={{ color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).red, fontSize: 12, fontWeight: '800' }}>✕</Text>
+                                <View style={{ backgroundColor: `${( C).red}15`, width: 24, height: 24, borderRadius: 12, alignItems: 'center', justifyContent: 'center' }}>
+                                  <Text style={{ color: ( C).red, fontSize: 12, fontWeight: '800' }}>✕</Text>
                                 </View>
                               </TouchableOpacity>
                             </View>
@@ -292,7 +294,7 @@ const TaskCard = memo(function TaskCard({ darkMode,
             )}
 
             <View style={{ marginTop: 12 }}>
-              <Text style={{ fontSize: 11, fontWeight: '600', color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkMuted, marginBottom: 8, letterSpacing: 0.5 }}>CHANGE TAG</Text>
+              <Text style={{ fontSize: 11, fontWeight: '600', color: ( C).inkMuted, marginBottom: 8, letterSpacing: 0.5 }}>CHANGE TAG</Text>
               <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
                 {DEFAULT_TAGS.map(t => {
                   const active = t.id === actualTagId
@@ -303,11 +305,11 @@ const TaskCard = memo(function TaskCard({ darkMode,
                       style={{
                         paddingHorizontal: 12, paddingVertical: 6,
                         borderRadius: 20, borderWidth: 1,
-                        backgroundColor: active ? t.dot : ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).bgInput,
-                        borderColor: active ? t.dot : ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).border,
+                        backgroundColor: active ? t.dot : ( C).bgInput,
+                        borderColor: active ? t.dot : ( C).border,
                       }}
                     >
-                      <Text style={{ fontSize: 11, fontWeight: '700', color: active ? '#FFF' : ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkMuted }}>
+                      <Text style={{ fontSize: 11, fontWeight: '700', color: active ? '#FFF' : ( C).inkMuted }}>
                         {t.label}
                       </Text>
                     </TouchableOpacity>
@@ -331,10 +333,8 @@ const styles = StyleSheet.create({
   },
   card: {
     borderRadius:  20,
-    backgroundColor: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).bgCard,
     padding:       18,
     borderWidth:   1,
-    borderColor:   ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).border,
     shadowColor:   '#000',
     shadowOffset:  { width: 0, height: 4 },
     shadowOpacity: 0.06,

--- a/src/components/TaskCard.js
+++ b/src/components/TaskCard.js
@@ -105,7 +105,7 @@ const TaskCard = memo(function TaskCard({ darkMode,
             {status === 'idle' && (
               <View style={{ flexDirection: 'row', gap: 6 }}>
                 <TouchableOpacity
-                  style={[styles.miniBtn, { backgroundColor: isToday ? palette.dot : ( C).border }]}
+                  style={[styles.miniBtn, { backgroundColor: isToday ? palette.dot : C.border }]}
                   onPress={onStart}
                   activeOpacity={0.8}
                   disabled={!isToday}
@@ -116,7 +116,7 @@ const TaskCard = memo(function TaskCard({ darkMode,
                 </TouchableOpacity>
                 {(task.sessions?.length ?? 0) > 0 && isToday && (
                   <TouchableOpacity
-                    style={[styles.miniBtn, { backgroundColor: ( C).emerald }]}
+                    style={[styles.miniBtn, { backgroundColor: C.emerald }]}
                     onPress={onDone}
                     activeOpacity={0.8}
                   >
@@ -142,7 +142,7 @@ const TaskCard = memo(function TaskCard({ darkMode,
                   <Text style={[styles.miniBtnOutlineText, { color: palette.dot }]}>|| Pause</Text>
                 </TouchableOpacity>
                 <TouchableOpacity
-                  style={[styles.miniBtn, { backgroundColor: ( C).emerald }]}
+                  style={[styles.miniBtn, { backgroundColor: C.emerald }]}
                   onPress={onDone}
                   activeOpacity={0.8}
                 >
@@ -195,7 +195,7 @@ const TaskCard = memo(function TaskCard({ darkMode,
             {/* Tags (if expanded) */}
             {taskTag && (
               <View style={{ marginBottom: 16 }}>
-                <Text style={{ fontSize: 11, fontWeight: '600', color: ( C).inkMuted, marginBottom: 8, letterSpacing: 0.5 }}>CURRENT TAG</Text>
+                <Text style={{ fontSize: 11, fontWeight: '600', color: C.inkMuted, marginBottom: 8, letterSpacing: 0.5 }}>CURRENT TAG</Text>
                 <View style={styles.tagsRow}>
                   <View style={[styles.tagChip, { backgroundColor: taskTag.bg, borderColor: taskTag.dot + '40' }]}>
                     <Text style={[styles.tagText, { color: taskTag.dot }]}>{taskTag.label}</Text>
@@ -208,7 +208,7 @@ const TaskCard = memo(function TaskCard({ darkMode,
             {task.sessions && task.sessions.length > 0 && (
               <View style={{ marginBottom: 16 }}>
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
-                  <Text style={{ fontSize: 11, fontWeight: '600', color: ( C).inkMuted, letterSpacing: 0.5 }}>
+                  <Text style={{ fontSize: 11, fontWeight: '600', color: C.inkMuted, letterSpacing: 0.5 }}>
                     SESSIONS (LAST 5 OF {task.sessions.length})
                   </Text>
                 </View>
@@ -235,19 +235,19 @@ const TaskCard = memo(function TaskCard({ darkMode,
                     const isEditing = editingId === group.groupKey
 
                     return (
-                      <View key={sId} style={{ marginBottom: 8, backgroundColor: ( C).bgInput, padding: 8, borderRadius: 10 }}>
+                      <View key={sId} style={{ marginBottom: 8, backgroundColor: C.bgInput, padding: 8, borderRadius: 10 }}>
                         {isEditing ? (
                           <View style={{ gap: 8 }}>
                             <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
                               <TextInput
-                                style={{ flex: 1, height: 36, backgroundColor: ( C).bgApp, borderRadius: 6, paddingHorizontal: 8, fontSize: 14, color: ( C).inkPrimary, fontWeight: '700' }}
+                                style={{ flex: 1, height: 36, backgroundColor: C.bgApp, borderRadius: 6, paddingHorizontal: 8, fontSize: 14, color: C.inkPrimary, fontWeight: '700' }}
                                 value={editStart}
                                 onChangeText={setEditStart}
                                 placeholder="Start"
                               />
-                              <Text style={{ color: ( C).inkMuted }}>to</Text>
+                              <Text style={{ color: C.inkMuted }}>to</Text>
                               <TextInput
-                                style={{ flex: 1, height: 36, backgroundColor: ( C).bgApp, borderRadius: 6, paddingHorizontal: 8, fontSize: 14, color: ( C).inkPrimary, fontWeight: '700' }}
+                                style={{ flex: 1, height: 36, backgroundColor: C.bgApp, borderRadius: 6, paddingHorizontal: 8, fontSize: 14, color: C.inkPrimary, fontWeight: '700' }}
                                 value={editEnd}
                                 onChangeText={setEditEnd}
                                 placeholder="End"
@@ -255,7 +255,7 @@ const TaskCard = memo(function TaskCard({ darkMode,
                             </View>
                             <View style={{ flexDirection: 'row', justifyContent: 'flex-end', gap: 8 }}>
                               <TouchableOpacity onPress={() => setEditingId(null)} style={{ padding: 6 }}>
-                                <Text style={{ color: ( C).inkMuted, fontSize: 12, fontWeight: '700' }}>Cancel</Text>
+                                <Text style={{ color: C.inkMuted, fontSize: 12, fontWeight: '700' }}>Cancel</Text>
                               </TouchableOpacity>
                               <TouchableOpacity onPress={() => saveEdit(group)} style={{ backgroundColor: palette.dot, paddingHorizontal: 12, paddingVertical: 6, borderRadius: 6 }}>
                                 <Text style={{ color: '#FFF', fontSize: 12, fontWeight: '700' }}>Save</Text>
@@ -268,19 +268,19 @@ const TaskCard = memo(function TaskCard({ darkMode,
                             onPress={() => handleEdit(group)}
                             style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}
                           >
-                            <Text style={{ fontSize: 13, color: palette.textColor, fontWeight: '600' }}>
-                              {formatTime(group.startTime)}  <Text style={{ color: palette.dot, opacity: 0.6 }}>to</Text>  {group.endTime ? formatTime(group.endTime) : <Text style={{ color: palette.dot, fontStyle: 'italic' }}>Active now</Text>}
+                            <Text style={{ fontSize: 13, color: darkMode ? C.inkPrimary : palette.textColor, fontWeight: '600' }}>
+                              {formatTime(group.startTime)}  <Text style={{ color: palette.dot, opacity: 0.7 }}>to</Text>  {group.endTime ? formatTime(group.endTime) : <Text style={{ color: palette.dot, fontStyle: 'italic' }}>Active now</Text>}
                             </Text>
                             <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-                              <Text style={{ fontSize: 12, color: ( C).inkMuted }}>{formatShort(group.totalDuration)}</Text>
-                              <TouchableOpacity 
+                              <Text style={{ fontSize: 12, color: darkMode ? C.inkSecondary : C.inkMuted }}>{formatShort(group.totalDuration)}</Text>
+                              <TouchableOpacity
                                 onPress={() => {
                                   group.sessionIds.forEach(id => onDeleteSession && onDeleteSession(id))
-                                }} 
+                                }}
                                 hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
                               >
-                                <View style={{ backgroundColor: `${( C).red}15`, width: 24, height: 24, borderRadius: 12, alignItems: 'center', justifyContent: 'center' }}>
-                                  <Text style={{ color: ( C).red, fontSize: 12, fontWeight: '800' }}>✕</Text>
+                                <View style={{ backgroundColor: 'rgba(239,68,68,0.15)', width: 24, height: 24, borderRadius: 12, alignItems: 'center', justifyContent: 'center' }}>
+                                  <Text style={{ color: '#EF4444', fontSize: 12, fontWeight: '800' }}>✕</Text>
                                 </View>
                               </TouchableOpacity>
                             </View>
@@ -294,7 +294,7 @@ const TaskCard = memo(function TaskCard({ darkMode,
             )}
 
             <View style={{ marginTop: 12 }}>
-              <Text style={{ fontSize: 11, fontWeight: '600', color: ( C).inkMuted, marginBottom: 8, letterSpacing: 0.5 }}>CHANGE TAG</Text>
+              <Text style={{ fontSize: 11, fontWeight: '600', color: C.inkMuted, marginBottom: 8, letterSpacing: 0.5 }}>CHANGE TAG</Text>
               <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
                 {DEFAULT_TAGS.map(t => {
                   const active = t.id === actualTagId
@@ -305,11 +305,11 @@ const TaskCard = memo(function TaskCard({ darkMode,
                       style={{
                         paddingHorizontal: 12, paddingVertical: 6,
                         borderRadius: 20, borderWidth: 1,
-                        backgroundColor: active ? t.dot : ( C).bgInput,
-                        borderColor: active ? t.dot : ( C).border,
+                        backgroundColor: active ? t.dot : C.bgInput,
+                        borderColor: active ? t.dot : C.border,
                       }}
                     >
-                      <Text style={{ fontSize: 11, fontWeight: '700', color: active ? '#FFF' : ( C).inkMuted }}>
+                      <Text style={{ fontSize: 11, fontWeight: '700', color: active ? '#FFF' : C.inkMuted }}>
                         {t.label}
                       </Text>
                     </TouchableOpacity>

--- a/src/components/TaskCard.js
+++ b/src/components/TaskCard.js
@@ -77,7 +77,7 @@ const TaskCard = memo(function TaskCard({ darkMode,
           <View style={styles.topRight}>
             <View style={styles.timeWrap}>
               {isActive && <View style={[styles.liveDot, { backgroundColor: palette.dot }]} />}
-              <Text style={[styles.timeText, { color: palette.textColor }]}>{timeText}</Text>
+              <Text style={[styles.timeText, { color: darkMode ? palette.dot : palette.textColor }]}>{timeText}</Text>
             </View>
             <TouchableOpacity onPress={handleFavorite} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
               <Text style={[styles.heart, isFavorite && styles.heartActive]}>
@@ -92,7 +92,7 @@ const TaskCard = memo(function TaskCard({ darkMode,
           <Text
             style={[
               styles.taskName,
-              { color: palette.textColor, flex: 1 },
+              { color: darkMode ? C.inkPrimary : palette.textColor, flex: 1 },
               isDone && { textDecorationLine: 'line-through' },
             ]}
             numberOfLines={2}

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -17,26 +17,27 @@ const Chevron = ({ color }) => (
 )
 
 // ── Menu row component ────────────────────────────────────────────────────────
-function MenuRow({ icon, label, right, onPress, danger,  noBorder }) {
+function MenuRow({ icon, label, right, onPress, danger, noBorder, darkMode }) {
+  const C = darkMode ? COLORS.dark : COLORS.light
   return (
     <TouchableOpacity
       onPress={onPress}
       activeOpacity={onPress ? 0.7 : 1}
       style={[
         styles.menuRow,
-        !noBorder && { borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).border },
-        danger && { backgroundColor: '#FFF1F1' },
+        !noBorder && { borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: C.border },
+        danger && { backgroundColor: darkMode ? '#2A0A0A' : '#FFF1F1' },
       ]}
     >
       {icon && (
-        <View style={[styles.menuIcon, { backgroundColor: danger ? '#FFE4E4' : ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).bgInput }]}>
+        <View style={[styles.menuIcon, { backgroundColor: danger ? (darkMode ? '#3A1010' : '#FFE4E4') : C.bgInput }]}>
           {icon}
         </View>
       )}
-      <Text style={[styles.menuLabel, { color: danger ? '#EF4444' : ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkPrimary }]}>{label}</Text>
+      <Text style={[styles.menuLabel, { color: danger ? '#EF4444' : C.inkPrimary }]}>{label}</Text>
       <View style={styles.menuRight}>
         {right}
-        {onPress && <Chevron color={danger ? '#EF4444' : ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkFaint} />}
+        {onPress && <Chevron color={danger ? '#EF4444' : C.inkFaint} />}
       </View>
     </TouchableOpacity>
   )
@@ -53,7 +54,7 @@ export default function ProfileScreen() {
     tasks,
     toggleFavorite,
   } = useTaskContext()
-  const _unused = (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light
+  const C = darkMode ? COLORS.dark : COLORS.light
 
   const [editingName, setEditingName] = useState(false)
   const [nameInput, setNameInput]     = useState(userName)
@@ -92,52 +93,52 @@ export default function ProfileScreen() {
 
   return (
     <ScrollView
-      style={[styles.container, { backgroundColor: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).bgApp }]}
+      style={[styles.container, { backgroundColor: C.bgApp }]}
       contentContainerStyle={{ paddingBottom: insets.bottom + 110 }}
       showsVerticalScrollIndicator={false}
       keyboardShouldPersistTaps="handled"
     >
       {/* ── Header ──────────────────────────────────────────────────────── */}
-      <View style={[styles.header, { paddingTop: insets.top + 14, backgroundColor: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).bgApp }]}>
-        <Text style={[styles.headerTitle, { color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkPrimary }]}>Profile</Text>
+      <View style={[styles.header, { paddingTop: insets.top + 14, backgroundColor: C.bgApp }]}>
+        <Text style={[styles.headerTitle, { color: C.inkPrimary }]}>Profile</Text>
         <TouchableOpacity
           onPress={toggleDarkMode}
-          style={[styles.headerBtn, { backgroundColor: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).bgPanel }]}
+          style={[styles.headerBtn, { backgroundColor: C.bgPanel }]}
         >
           <Text style={{ fontSize: 17 }}>{darkMode ? '☀️' : '🌙'}</Text>
         </TouchableOpacity>
       </View>
 
       {/* ── User card ───────────────────────────────────────────────────── */}
-      <View style={[styles.userCard, { backgroundColor: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).bgPanel, marginHorizontal: 16, marginBottom: 12 }]}>
-        <View style={[styles.avatarCircle, { backgroundColor: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).amber }]}>
+      <View style={[styles.userCard, { backgroundColor: C.bgPanel, marginHorizontal: 16, marginBottom: 12 }]}>
+        <View style={[styles.avatarCircle, { backgroundColor: C.amber }]}>
           <Text style={styles.avatarText}>{initials || '?'}</Text>
         </View>
 
         <View style={{ flex: 1, gap: 2 }}>
           {editingName ? (
             <TextInput
-              style={[styles.nameInput, { color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkPrimary, borderBottomColor: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).amber }]}
+              style={[styles.nameInput, { color: C.inkPrimary, borderBottomColor: C.amber }]}
               value={nameInput}
               onChangeText={setNameInput}
               onSubmitEditing={handleSaveName}
               onBlur={handleSaveName}
               autoFocus
-              selectionColor={( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).amber}
+              selectionColor={C.amber}
               maxLength={MAX_USER_NAME}
             />
           ) : (
-            <Text style={[styles.userName, { color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkPrimary }]}>{displayName}</Text>
+            <Text style={[styles.userName, { color: C.inkPrimary }]}>{displayName}</Text>
           )}
           {displayEmail ? (
-            <Text style={[styles.userEmail, { color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkMuted }]}>{displayEmail}</Text>
+            <Text style={[styles.userEmail, { color: C.inkMuted }]}>{displayEmail}</Text>
           ) : (
-            <Text style={[styles.userEmail, { color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkFaint }]}>No email set</Text>
+            <Text style={[styles.userEmail, { color: C.inkFaint }]}>No email set</Text>
           )}
         </View>
 
         <TouchableOpacity
-          style={[styles.editBtn, { backgroundColor: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).amber }]}
+          style={[styles.editBtn, { backgroundColor: C.amber }]}
           onPress={() => { setNameInput(displayName); setEditingName(true) }}
         >
           <Text style={styles.editBtnText}>✎</Text>
@@ -145,17 +146,17 @@ export default function ProfileScreen() {
       </View>
 
       {/* ── Favorites ───────────────────────────────────────────────────── */}
-      <View style={[styles.section, { backgroundColor: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).bgPanel, marginHorizontal: 16, marginBottom: 12 }]}>
+      <View style={[styles.section, { backgroundColor: C.bgPanel, marginHorizontal: 16, marginBottom: 12 }]}>
         <MenuRow
+          darkMode={darkMode}
           icon={<Text style={{ fontSize: 16 }}>♥</Text>}
           label={`Favorites${favoriteTasks.length > 0 ? `  ·  ${favoriteTasks.length}` : ''}`}
           right={favoriteTasks.length > 0 && (
-            <Text style={[styles.badge, { backgroundColor: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).amberLight, color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).amber }]}>
+            <Text style={[styles.badge, { backgroundColor: C.amberLight, color: C.amber }]}>
               {favoriteTasks.length}
             </Text>
           )}
           onPress={favoriteTasks.length > 0 ? () => setShowFavorites(v => !v) : undefined}
-          
           noBorder={showFavorites && favoriteTasks.length > 0}
         />
 
@@ -171,13 +172,13 @@ export default function ProfileScreen() {
                   key={`${task.id}-${task.dateKey}-${i}`}
                   style={[
                     styles.favRow,
-                    { borderTopColor: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).border },
+                    { borderTopColor: C.border },
                     i > 0 && { borderTopWidth: StyleSheet.hairlineWidth },
                   ]}
                 >
                   <View style={[styles.favDot, { backgroundColor: palette.dot }]} />
                   <View style={{ flex: 1, gap: 4 }}>
-                    <Text style={[styles.favName, { color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkPrimary }]} numberOfLines={1}>
+                    <Text style={[styles.favName, { color: C.inkPrimary }]} numberOfLines={1}>
                       {task.name}
                     </Text>
                     {tagItem && (
@@ -190,7 +191,7 @@ export default function ProfileScreen() {
                   </View>
                   <View style={{ alignItems: 'flex-end', gap: 4 }}>
                     {ms > 0 && (
-                      <Text style={[styles.favTime, { color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkMuted }]}>{formatShort(ms)}</Text>
+                      <Text style={[styles.favTime, { color: C.inkMuted }]}>{formatShort(ms)}</Text>
                     )}
                     <TouchableOpacity onPress={() => toggleFavorite(task.id)} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
                       <Text style={{ fontSize: 16, color: '#F472B6' }}>♥</Text>
@@ -203,8 +204,8 @@ export default function ProfileScreen() {
         )}
 
         {favoriteTasks.length === 0 && (
-          <View style={[styles.emptyFav, { borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).border }]}>
-            <Text style={[styles.emptyFavText, { color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkFaint }]}>
+          <View style={[styles.emptyFav, { borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: C.border }]}>
+            <Text style={[styles.emptyFavText, { color: C.inkFaint }]}>
               Tap ♡ on any task to add it here
             </Text>
           </View>
@@ -212,50 +213,50 @@ export default function ProfileScreen() {
       </View>
 
       {/* ── Settings ────────────────────────────────────────────────────── */}
-      <View style={[styles.section, { backgroundColor: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).bgPanel, marginHorizontal: 16, marginBottom: 12 }]}>
+      <View style={[styles.section, { backgroundColor: C.bgPanel, marginHorizontal: 16, marginBottom: 12 }]}>
         <MenuRow
+          darkMode={darkMode}
           icon={<Text style={{ fontSize: 16 }}>{darkMode ? '☀️' : '🌙'}</Text>}
           label="Dark Mode"
           right={
             <Switch
               value={darkMode}
               onValueChange={toggleDarkMode}
-              trackColor={{ false: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).border, true: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).amber }}
+              trackColor={{ false: C.border, true: C.amber }}
               thumbColor="#FFFFFF"
             />
           }
-          
         />
         <MenuRow
+          darkMode={darkMode}
           icon={<Text style={{ fontSize: 16 }}>🔔</Text>}
           label="Notifications"
           right={
             <Switch
               value={notificationsEnabled}
               onValueChange={toggleNotifications}
-              trackColor={{ false: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).border, true: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).amber }}
+              trackColor={{ false: C.border, true: C.amber }}
               thumbColor="#FFFFFF"
             />
           }
-          
           noBorder={true}
         />
       </View>
 
       {/* ── Sign out ─────────────────────────────────────────────────────── */}
-      <View style={[styles.section, { backgroundColor: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).bgPanel, marginHorizontal: 16, marginBottom: 12 }]}>
+      <View style={[styles.section, { backgroundColor: C.bgPanel, marginHorizontal: 16, marginBottom: 12 }]}>
         <MenuRow
+          darkMode={darkMode}
           icon={<Text style={{ fontSize: 16 }}>→</Text>}
           label="Sign Out"
           onPress={logout}
           danger
-          
           noBorder={true}
         />
       </View>
 
       {/* App info */}
-      <Text style={[styles.appVer, { color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkFaint }]}>Echo  ·  v1.0</Text>
+      <Text style={[styles.appVer, { color: C.inkFaint }]}>Echo  ·  v1.0</Text>
     </ScrollView>
   )
 }

--- a/src/screens/StatsScreen.js
+++ b/src/screens/StatsScreen.js
@@ -13,6 +13,7 @@ export default function StatsScreen() {
   const insets = useSafeAreaInsets()
   const { tasks, darkMode, tick, selDate, weekStart, toggleDarkMode } = useTaskContext()
   
+  const C = darkMode ? COLORS.dark : COLORS.light
   const [modeIdx, setModeIdx] = useState(0)
   const mode = MODES[modeIdx].toLowerCase()
 
@@ -75,39 +76,39 @@ export default function StatsScreen() {
 
   return (
     <ScrollView
-      style={[styles.container, { backgroundColor: '#F8F9FA' }]}
+      style={[styles.container, { backgroundColor: C.bgApp }]}
       contentContainerStyle={{ paddingBottom: insets.bottom + 110 }}
       showsVerticalScrollIndicator={false}
     >
       {/* Header */}
-      <View style={[styles.header, { paddingTop: insets.top + 14, backgroundColor: '#F8F9FA' }]}>
+      <View style={[styles.header, { paddingTop: insets.top + 14, backgroundColor: C.bgApp }]}>
         <View style={{ flex: 1 }}>
-          <Text style={[styles.title, { color: '#1A1A1A' }]}>Overview</Text>
-          <Text style={[styles.subtitle, { color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkMuted }]}>Your productivity at a glance</Text>
+          <Text style={[styles.title, { color: C.inkPrimary }]}>Overview</Text>
+          <Text style={[styles.subtitle, { color: C.inkMuted }]}>Your productivity at a glance</Text>
         </View>
         <TouchableOpacity
           onPress={toggleDarkMode}
-          style={[styles.themeBtn, { backgroundColor: '#FFFFFF' }]}
+          style={[styles.themeBtn, { backgroundColor: C.bgPanel }]}
         >
           <Text style={{ fontSize: 17 }}>{darkMode ? '☀️' : '🌙'}</Text>
         </TouchableOpacity>
       </View>
 
       {/* Mode toggle */}
-      <View style={[styles.modeWrap, { backgroundColor: '#FFFFFF', marginHorizontal: 16, marginBottom: 14 }]}>
+      <View style={[styles.modeWrap, { backgroundColor: C.bgPanel, marginHorizontal: 16, marginBottom: 14 }]}>
         {MODES.map((m, i) => (
           <TouchableOpacity
             key={m}
             style={[
               styles.modeBtn,
-              modeIdx === i && { backgroundColor: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).amber },
+              modeIdx === i && { backgroundColor: C.amber },
             ]}
             onPress={() => setModeIdx(i)}
             activeOpacity={0.75}
           >
             <Text style={[
               styles.modeBtnText,
-              { color: modeIdx === i ? '#FFFFFF' : ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkMuted },
+              { color: modeIdx === i ? '#FFFFFF' : C.inkMuted },
             ]}>
               {m}
             </Text>
@@ -116,22 +117,22 @@ export default function StatsScreen() {
       </View>
 
       {/* Donut + legend */}
-      <View style={[styles.card, { backgroundColor: '#FFFFFF', marginHorizontal: 16, marginBottom: 14 }]}>
-        <Text style={[styles.cardTitle, { color: '#1A1A1A' }]}>Distribution</Text>
+      <View style={[styles.card, { backgroundColor: C.bgPanel, marginHorizontal: 16, marginBottom: 14 }]}>
+        <Text style={[styles.cardTitle, { color: C.inkPrimary }]}>Distribution</Text>
 
         <View style={styles.donutRow}>
           <DonutChart darkMode={darkMode} done={done} active={active} idle={idle}  />
 
           <View style={styles.legend}>
             {[
-              { label: 'Done',   value: done,   color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).emerald },
-              { label: 'Active', value: active, color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).amber   },
-              { label: 'Idle',   value: idle,   color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkFaint },
+              { label: 'Done',   value: done,   color: C.emerald },
+              { label: 'Active', value: active, color: C.amber   },
+              { label: 'Idle',   value: idle,   color: C.inkFaint },
             ].map(item => (
               <View key={item.label} style={styles.legendRow}>
                 <View style={[styles.legendDot, { backgroundColor: item.color }]} />
-                <Text style={[styles.legendLabel, { color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkMuted }]}>{item.label}</Text>
-                <Text style={[styles.legendValue, { color: '#1A1A1A' }]}>{item.value}</Text>
+                <Text style={[styles.legendLabel, { color: C.inkMuted }]}>{item.label}</Text>
+                <Text style={[styles.legendValue, { color: C.inkPrimary }]}>{item.value}</Text>
               </View>
             ))}
           </View>
@@ -139,8 +140,8 @@ export default function StatsScreen() {
       </View>
 
       {/* Summary stats */}
-      <View style={[styles.card, { backgroundColor: '#FFFFFF', marginHorizontal: 16, marginBottom: 14 }]}>
-        <Text style={[styles.cardTitle, { color: '#1A1A1A' }]}>Summary</Text>
+      <View style={[styles.card, { backgroundColor: C.bgPanel, marginHorizontal: 16, marginBottom: 14 }]}>
+        <Text style={[styles.cardTitle, { color: C.inkPrimary }]}>Summary</Text>
         <View style={styles.statsRow}>
           {[
             { label: 'Total',   value: String(total) },
@@ -151,12 +152,12 @@ export default function StatsScreen() {
               key={item.label}
               style={[
                 styles.statCell,
-                { borderColor: '#E5E7EB' },
+                { borderColor: C.border },
                 i < 2 && { borderRightWidth: StyleSheet.hairlineWidth },
               ]}
             >
-              <Text style={[styles.statValue, { color: '#1A1A1A' }]}>{item.value}</Text>
-              <Text style={[styles.statLabel, { color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkMuted }]}>{item.label}</Text>
+              <Text style={[styles.statValue, { color: C.inkPrimary }]}>{item.value}</Text>
+              <Text style={[styles.statLabel, { color: C.inkMuted }]}>{item.label}</Text>
             </View>
           ))}
         </View>
@@ -174,17 +175,17 @@ export default function StatsScreen() {
         if (tagTimes.length === 0) return null
 
         return (
-          <View style={[styles.card, { backgroundColor: '#FFFFFF', marginHorizontal: 16, marginBottom: 14 }]}>
-            <Text style={[styles.cardTitle, { color: '#1A1A1A' }]}>Time by Tag</Text>
+          <View style={[styles.card, { backgroundColor: C.bgPanel, marginHorizontal: 16, marginBottom: 14 }]}>
+            <Text style={[styles.cardTitle, { color: C.inkPrimary }]}>Time by Tag</Text>
             {tagTimes.map((item, i) => (
               <React.Fragment key={item.tag.id}>
-                {i > 0 && <View style={{ height: 1, backgroundColor: (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark.border : COLORS.light.border }} />}
+                {i > 0 && <View style={{ height: 1, backgroundColor: C.border }} />}
                 <View style={styles.taskRow}>
                   <View style={[styles.taskDot, { backgroundColor: item.tag.dot }]} />
-                  <Text style={[styles.taskName, { color: (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark.inkPrimary : COLORS.light.inkPrimary }]} numberOfLines={1}>
+                  <Text style={[styles.taskName, { color: C.inkPrimary }]} numberOfLines={1}>
                     {item.tag.label}
                   </Text>
-                  <Text style={[styles.taskTime, { color: (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark.inkMuted : COLORS.light.inkMuted }]}>
+                  <Text style={[styles.taskTime, { color: C.inkMuted }]}>
                     {formatShort(item.ms)}
                   </Text>
                 </View>
@@ -196,19 +197,19 @@ export default function StatsScreen() {
 
       {/* Task breakdown */}
       {taskGroups.length > 0 && (
-        <View style={[styles.card, { backgroundColor: '#FFFFFF', marginHorizontal: 16, marginBottom: 14 }]}>
-          <Text style={[styles.cardTitle, { color: '#1A1A1A' }]}>Tasks</Text>
+        <View style={[styles.card, { backgroundColor: C.bgPanel, marginHorizontal: 16, marginBottom: 14 }]}>
+          <Text style={[styles.cardTitle, { color: C.inkPrimary }]}>Tasks</Text>
           {taskGroups.map((task, i) => {
             const palette = getTaskPalette(task) || { dot: '#7C5CFC', bg: '#F1E9FF', border: '#DDD6FE' }
             return (
               <React.Fragment key={task.parentId || task.id}>
-                {i > 0 && <View style={{ height: 1, backgroundColor: (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark.border : COLORS.light.border }} />}
+                {i > 0 && <View style={{ height: 1, backgroundColor: C.border }} />}
                 <View style={styles.taskRow}>
                   <View style={[styles.taskDot, { backgroundColor: palette.dot }]} />
-                  <Text style={[styles.taskName, { color: (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark.inkPrimary : COLORS.light.inkPrimary }]} numberOfLines={1}>
+                  <Text style={[styles.taskName, { color: C.inkPrimary }]} numberOfLines={1}>
                     {task.name}
                   </Text>
-                  <Text style={[styles.taskTime, { color: (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark.inkMuted : COLORS.light.inkMuted }]}>
+                  <Text style={[styles.taskTime, { color: C.inkMuted }]}>
                     {task.ms > 0 ? formatShort(task.ms) : '—'}
                   </Text>
                 </View>

--- a/src/screens/TimelineScreen.js
+++ b/src/screens/TimelineScreen.js
@@ -191,23 +191,24 @@ export default function TimelineScreen() {
     return arr
   }, [])
 
+  const C          = darkMode ? COLORS.dark : COLORS.light
   const selDateObj = new Date(selDate + 'T12:00:00')
   const dayLabel   = `${DAY_FULL[selDateObj.getDay()]}, ${selDateObj.getDate()} ${MONTH_FULL[selDateObj.getMonth()]}`
 
   // ── Render ──────────────────────────────────────────────────────────────────
 
   return (
-    <View style={[styles.container, { backgroundColor: '#F8F9FA' }]}>
+    <View style={[styles.container, { backgroundColor: C.bgApp }]}>
 
       {/* ── Header ──────────────────────────────────────────────────────────── */}
-      <View style={[styles.header, { backgroundColor: '#F8F9FA', paddingTop: insets.top + 14 }]}>
+      <View style={[styles.header, { backgroundColor: C.bgApp, paddingTop: insets.top + 14 }]}>
         <View style={{ flex: 1 }}>
-          <Text style={[styles.title, { color: '#1A1A1A' }]}>Timeline</Text>
-          <Text style={[styles.dayLabel, { color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkMuted }]}>{dayLabel}</Text>
+          <Text style={[styles.title, { color: C.inkPrimary }]}>Timeline</Text>
+          <Text style={[styles.dayLabel, { color: C.inkMuted }]}>{dayLabel}</Text>
         </View>
         <TouchableOpacity
           onPress={toggleDarkMode}
-          style={[styles.themeBtn, { backgroundColor: '#FFFFFF' }]}
+          style={[styles.themeBtn, { backgroundColor: C.bgPanel }]}
         >
           <Text style={{ fontSize: 17 }}>{darkMode ? '☀️' : '🌙'}</Text>
         </TouchableOpacity>
@@ -227,7 +228,7 @@ export default function TimelineScreen() {
       {/* ── Timeline scroll ──────────────────────────────────────────────────── */}
       <ScrollView
         ref={scrollRef}
-        style={{ flex: 1, backgroundColor: '#F8F9FA' }}
+        style={{ flex: 1, backgroundColor: C.bgApp }}
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{ paddingBottom: insets.bottom + 110 }}
       >
@@ -238,11 +239,11 @@ export default function TimelineScreen() {
             const top    = (h - TIMELINE_START) * HOUR_H
             const label = `${String(h).padStart(2, '0')}:00`
             return (
-              <View key={h} style={[styles.hourRow, { top, borderTopColor: '#E5E7EB' }]}>
+              <View key={h} style={[styles.hourRow, { top, borderTopColor: C.border }]}>
                 <View style={styles.hourLabelWrap}>
-                  <Text style={[styles.hourNum, { color: ( (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark : COLORS.light).inkMuted, fontSize: 11 }]}>{label}</Text>
+                  <Text style={[styles.hourNum, { color: C.inkMuted, fontSize: 11 }]}>{label}</Text>
                 </View>
-                <View style={[styles.hourLine, { backgroundColor: '#E5E7EB' }]} />
+                <View style={[styles.hourLine, { backgroundColor: C.border }]} />
               </View>
             )
           })}
@@ -287,7 +288,7 @@ export default function TimelineScreen() {
                       zIndex:          block.isLive ? 3 : 1,
                       minHeight:       0,
                       // No shadow for finished blocks to keep them flat and distinct
-                      shadowOpacity:   (typeof darkMode !== 'undefined' && darkMode) ? 0.3 : 0,
+                      shadowOpacity:   darkMode ? 0.3 : 0,
                       elevation:       block.isLive ? 3 : 0,
                     },
                    ]}
@@ -360,12 +361,12 @@ export default function TimelineScreen() {
                     shadowColor:     palette.dot,
                   }]} />
                   <Text
-                    style={[styles.pointerName, { color: (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark.inkPrimary : COLORS.light.inkPrimary }]}
+                    style={[styles.pointerName, { color: C.inkPrimary }]}
                     numberOfLines={1}
                   >
                     {block.name}
                   </Text>
-                  <View style={[styles.pointerBar, { backgroundColor: (typeof darkMode !== 'undefined' && darkMode) ? COLORS.dark.inkFaint : COLORS.light.inkFaint }]} />
+                  <View style={[styles.pointerBar, { backgroundColor: C.inkFaint }]} />
                   <Text style={[styles.pointerTime, { color: palette.dot }]}>
                     {formatLive(totalMs)}
                   </Text>


### PR DESCRIPTION
## Summary

- **TaskCard**: `StyleSheet.create()` est évalué une seule fois au chargement — `darkMode` était `undefined`, les cartes restaient toujours blanches. Fond/bordure déplacés en inline styles avec `const C = darkMode ? COLORS.dark : COLORS.light`
- **TaskCard texte**: `palette.textColor` (ex: `#9A3412` pour Home) est une couleur sombre pour fond clair — illisible en dark mode. Nom de tâche → `C.inkPrimary`, timer → `palette.dot`
- **TaskCard sessions**: texte `19:46 to 20:46` invisible (même cause). Durée peu visible. Bouton `✕` cassé car `C.red` n'existe pas dans les tokens COLORS
- **TimelineScreen**: fond et grille horaire hardcodés `#F8F9FA`/`#E5E7EB` — aucun support dark mode
- **StatsScreen**: tous les fonds et textes hardcodés `#F8F9FA`, `#FFFFFF`, `#1A1A1A`
- **ProfileScreen**: `MenuRow` référençait `darkMode` hors de sa portée (pas de prop) → toujours light theme

## Test plan

- [x] Activer le dark mode depuis n'importe quel écran (bouton ☀️/🌙)
- [x] Vérifier Today : cartes visibles avec texte lisible (blanc lavande sur fond sombre)
- [ ] Expand une carte → section sessions lisible, bouton ✕ rouge visible
- [ ] Vérifier Timeline : fond sombre, grille horaire visible
- [ ] Vérifier Overview (Stats) : fond sombre, textes lisibles
- [ ] Vérifier Profile : textes, MenuRow et labels lisibles
- [ ] Repasser en light mode → tout revient correctement

🤖 Generated with [Claude Code](https://claude.com/claude-code)